### PR TITLE
chore: issue생성 시 branch 자동 생성

### DIFF
--- a/.github/issue-branch.yml
+++ b/.github/issue-branch.yml
@@ -1,0 +1,26 @@
+branchName: short
+autoCloseIssue: true
+branches:
+  - label: docs📝
+    prefix: docs/
+  - label: hotfix🚑
+    prefix: hotfix/
+  - label: refactor♻️
+    prefix: refactor/
+  - label: env🔧
+    prefix: chore/
+  - label: release👷
+    prefix: release/
+  - label: test✅
+    prefix: test/
+  - label: bug🐛
+    prefix: fix/
+  - label: question🏷️
+    skip: true
+  - label: '*'
+    prefix: feature/
+commentMessage: 'Branch ${branchName} created for issue: ${issue.title}'
+copyIssueLabelsToPR: true
+copyIssueAssigneeToPR: true
+copyIssueProjectsToPR: true
+copyIssueMilestoneToPR: true

--- a/.github/workflows/create-issue-branch.yml
+++ b/.github/workflows/create-issue-branch.yml
@@ -1,0 +1,15 @@
+name: Create Issue Branch
+on:
+  issues:
+    types: [assigned]
+
+jobs:
+  create_issue_branch_job:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create Issue Branch
+        uses: robvanderleek/create-issue-branch@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Echo branch name
+        run: echo ${{ steps.Create_Issue_Branch.outputs.branchName }}


### PR DESCRIPTION
- [x] ✅ PR 제목의 형식을 잘 작성했나요? e.g. `feat: PR을 등록한다.` 
- [ ] ✅ 테스트는 잘 통과했나요?
- [ ] ✅ 빌드는 성공했나요?
- [ ] ✅ 불필요한 코드는 제거했나요?
- [x] ✅ 이슈는 등록했나요?
- [x] ✅ 라벨은 등록했나요?
- [ ] ✅ 코드 컨벤션은 지켰나요?
- [ ] ✅ pr 워크플로우를 돌려주세요.

## 작업 내용
이슈 생성하여 assigned하면 해당 이슈의 브랜치가
자동 생성 된다. 이슈 라벨에 따라 브랜치 prefix를 달리 하였다.

## 주의사항
### 참고문서
* https://github.com/marketplace/actions/create-issue-branch

Closes #6 



