### PR TITLE
Feature/issue 5

### DIFF
--- a/src/main/java/com/compono/ibackend/user/domain/User.java
+++ b/src/main/java/com/compono/ibackend/user/domain/User.java
@@ -1,16 +1,30 @@
 package com.compono.ibackend.user.domain;
 
+import com.compono.ibackend.user.enumType.OauthProvider;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
+@Table(name = "`user`")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String email;
+
     private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    private OauthProvider oauthProvider;
+
+    private String oauthProviderUniqueKey;
+
+    private Boolean isAuthenticated;
 }

--- a/src/main/java/com/compono/ibackend/user/domain/User.java
+++ b/src/main/java/com/compono/ibackend/user/domain/User.java
@@ -1,0 +1,16 @@
+package com.compono.ibackend.user.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nickname;
+}

--- a/src/main/java/com/compono/ibackend/user/enumType/OauthProvider.java
+++ b/src/main/java/com/compono/ibackend/user/enumType/OauthProvider.java
@@ -1,0 +1,5 @@
+package com.compono.ibackend.user.enumType;
+
+public enum OauthProvider {
+    GOOGLE, KAKAO, APPLE
+}


### PR DESCRIPTION
- 기본적인 ERD 반영 User Entity 클래스 입니다.
  - OauthProvicer(Enum) : Oauth 제공자 (유저의 로그인 타입)
  
- isAuthenticated(Boolean) : 이메일 또는 추후 폰 인증여부
   - Boolean 타입을 일단 사용했습니다. DB에 tinyint로 저장되는데, 0 또는 1로 나타내집니다.
   - 예를들어, AuthenticationStatus같이 Enum을 사용하는게 가독성에서는 좋을것 같습니다. 
   - 하지만 데이터 용량을 생각하면 Boolean이 효율적인데 어떻게 생각하시나요? 