### PR TITLE
feat: Auditing 기능(#19)

### DIFF
--- a/src/main/java/com/compono/ibackend/common/auditor/AuditorAwareImpl.java
+++ b/src/main/java/com/compono/ibackend/common/auditor/AuditorAwareImpl.java
@@ -1,0 +1,18 @@
+package com.compono.ibackend.common.auditor;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AuditorAwareImpl implements AuditorAware<String> {
+    
+    @Override
+    public Optional<String> getCurrentAuditor() {
+        String name = SecurityContextHolder.getContext().getAuthentication().getName();
+        return Optional.ofNullable(name);
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/compono/ibackend/common/entity/BaseTimeEntity.java
@@ -1,0 +1,34 @@
+package com.compono.ibackend.common.entity;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+@EntityListeners(value = AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    @LastModifiedBy
+    private String modifiedBy;
+
+    private LocalDateTime deletedAt;
+    
+    public void setDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/compono/ibackend/config/JpaAuditingConfig.java
+++ b/src/main/java/com/compono/ibackend/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.compono.ibackend.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}


### PR DESCRIPTION
1. JpaAuditingConfig: @EnableJpaAuditing
2. BaseTimeEntity: createdAt, modifiedAt, modifiedBy, deletedAt
- 일단 soft delete 로 생각해서 구현했습니다.
- 삭제시 setDeletedAt 메서드를 호출해서 update 쿼리를 날려주는식으로 구현하려고 합니다. 
- soft delete 시 유저 엔티티에 필드를 추가하거나, deletedAt 에 일자가 있다면 삭제된 것으로 판단할수도 있고 여러 방식이 있을것 같은데 어떤방식이 좋을까요?
- 아니면 어제 재형님은 완전히 삭제하는 식으로 생각한다 하셨는데 이쪽으로 구현할지 여부?
  
3. AuditingAwareImpl
- 시큐리티 컨텍스트에서 유저이메일 또는 식별자를 가져와 modifiedBy 적용
- 해당 부분은 시큐리티 구현 여부에 따라 적용이 달라질 듯싶습니다. (UserPrincipal, UserDetails 상세구현 여부) @rr8602 