### PR TITLE
feat: User Entity 고도화 및 상태추가(#31)

### DIFF
--- a/src/main/java/com/compono/ibackend/user/domain/User.java
+++ b/src/main/java/com/compono/ibackend/user/domain/User.java
@@ -1,6 +1,10 @@
 package com.compono.ibackend.user.domain;
 
+import static lombok.AccessLevel.PROTECTED;
+
 import com.compono.ibackend.user.enumType.OauthProvider;
+import com.compono.ibackend.user.enumType.UserStatus;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -8,23 +12,35 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "`user`")
 public class User {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
     private Long id;
 
+    @Column(name = "email", nullable = false, length = 255)
     private String email;
 
+    @Column(name = "nickname", nullable = false, length = 100)
     private String nickname;
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "oauth_provider", nullable = false)
     private OauthProvider oauthProvider;
 
+    @Column(name = "oauth_provider_unique_key")
     private String oauthProviderUniqueKey;
 
+    @Column(name = "is_authenticated", nullable = false)
     private Boolean isAuthenticated;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "user_status", nullable = false)
+    private UserStatus userStatus;
 }

--- a/src/main/java/com/compono/ibackend/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/compono/ibackend/user/domain/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.compono.ibackend.user.domain.repository;
+
+import com.compono.ibackend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/compono/ibackend/user/enumType/UserStatus.java
+++ b/src/main/java/com/compono/ibackend/user/enumType/UserStatus.java
@@ -1,0 +1,7 @@
+package com.compono.ibackend.user.enumType;
+
+public enum UserStatus {
+    ACTIVE,
+    DORMANT,
+    DELETED
+}

--- a/src/test/java/com/compono/ibackend/user/enumType/OauthProviderTest.java
+++ b/src/test/java/com/compono/ibackend/user/enumType/OauthProviderTest.java
@@ -1,0 +1,23 @@
+package com.compono.ibackend.user.enumType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OauthProviderTest {
+
+    @Test
+    @DisplayName("values test")
+    void values() {
+        OauthProvider[] values = OauthProvider.values();
+        assertThat(values.length).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("valueOf test")
+    void valueOf() {
+        OauthProvider oauthProvider = OauthProvider.valueOf("GOOGLE");
+        assertThat(oauthProvider).isSameAs(OauthProvider.GOOGLE);
+    }
+}

--- a/src/test/java/com/compono/ibackend/user/enumType/UserStatusTest.java
+++ b/src/test/java/com/compono/ibackend/user/enumType/UserStatusTest.java
@@ -1,0 +1,23 @@
+package com.compono.ibackend.user.enumType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UserStatusTest {
+
+    @Test
+    @DisplayName("values test")
+    void values() {
+        UserStatus[] values = UserStatus.values();
+        assertThat(values.length).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("valueOf test")
+    void valueOf() {
+        UserStatus active = UserStatus.valueOf("ACTIVE");
+        assertThat(active).isSameAs(UserStatus.ACTIVE);
+    }
+}


### PR DESCRIPTION
1. @Column 정의 및 nullable false 적용
- email, nickname, oauth_provider, is_authenticated, user_status
2. UserStatus enum 정의 및 엔티티 적용
- ACTIVE(활동), DORMANT(휴면), DELETED(삭제)
3. UserRepository 추가
4. OauthProver, UserStatus unit test