### PR TITLE
feat: JwtProvider 디펜던시 & 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,11 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 
+    //jwt
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 }
 
 test {
@@ -147,7 +152,7 @@ tasks.withType(JavaCompile) {
 
 // java source set 에 querydsl QClass 위치 추가
 sourceSets {
-    main.java.srcDirs += [ generated ]
+    main.java.srcDirs += [generated]
 }
 
 // gradle clean 시에 QClass 디렉토리 삭제

--- a/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
+++ b/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
@@ -1,0 +1,70 @@
+package com.compono.ibackend.common.utils.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+import java.util.Map;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.issuer}")
+    private String issuer;
+
+    @Value("${jwt.access-token-expiration-minute}")
+    private long accessTokenExpirationMinute;
+
+    @Value("${jwt.refresh-token-expiration-minute}")
+    private long refreshTokenExpirationMinute;
+
+    // Claim : JWT 에 넣을 내용(eg body, 부가적으로 사용할 정보를 넣을 수 있음)
+    private Map<String, Object> createClaims(String username) {
+        return Map.of("username", username);
+    }
+
+    public String createAccessToken(String username) {
+        Instant now = Instant.now();
+        Map<String, Object> claims = createClaims(username);
+        return Jwts.builder()
+                .issuer(issuer)
+                .subject(username)
+                .claims(claims)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(accessTokenExpirationMinute, ChronoUnit.MINUTES)))
+                .signWith(getSecretKey())
+                .compact();
+    }
+
+    public String createRefreshToken(String username) {
+        Instant now = Instant.now();
+        return Jwts.builder()
+                .issuer(issuer)
+                .subject(username)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(now.plus(refreshTokenExpirationMinute, ChronoUnit.MINUTES)))
+                .signWith(getSecretKey())
+                .compact();
+    }
+
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSecretKey())
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    private SecretKey getSecretKey() {
+        return Keys.hmacShaKeyFor(this.secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
+++ b/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
@@ -15,16 +15,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtProvider {
 
-    @Value("${jwt.secret}")
+    @Value("${spring.jwt.secret}")
     private String secretKey;
 
-    @Value("${jwt.issuer}")
+    @Value("${spring.jwt.issuer}")
     private String issuer;
 
-    @Value("${jwt.access-token-expiration-minute}")
+    @Value("${spring.jwt.access-token-expiration-minute}")
     private long accessTokenExpirationMinute;
 
-    @Value("${jwt.refresh-token-expiration-minute}")
+    @Value("${spring.jwt.refresh-token-expiration-minute}")
     private long refreshTokenExpirationMinute;
 
     // Claim : JWT 에 넣을 내용(eg body, 부가적으로 사용할 정보를 넣을 수 있음)

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -3,13 +3,21 @@ package com.compono.ibackend.common.utils.jwt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.jsonwebtoken.Claims;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @DisplayName("JWT 발급, 파싱 테스트")
-@SpringBootTest(classes = {JwtProvider.class})
+@SpringBootTest(classes = {JwtProvider.class},
+        properties = {
+                "jwt.secret=sdjkjskjdkjskdjkswdnlkqwnlfkdnlkqwnfkqwnf",
+                "jwt.issuer=compono",
+                "jwt.access-token-expiration-minute=30",
+                "jwt.refresh-token-expiration-minute=7200"}
+)
 class JwtProviderTest {
 
     @Autowired
@@ -33,6 +41,7 @@ class JwtProviderTest {
 
     @Test
     void getClaims() {
+        Instant now = Instant.now();
         String email = "test@gmail.com";
         String accessToken = jwtProvider.createAccessToken(email);
 
@@ -42,5 +51,6 @@ class JwtProviderTest {
 
         assertThat(subject).isEqualTo(email);
         assertThat(username).isEqualTo(email);
+        assertThat(claims.getExpiration()).isBefore(now.plus(7199, ChronoUnit.MINUTES));
     }
 }

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -14,14 +14,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest(
         classes = {JwtProvider.class},
         properties = {
-            "spring.jwt.secret=sdjkjskjdkjskdjkswdnlkqwnlfkdnlkqwnfkqwnf",
-            "spring.jwt.issuer=compono",
-            "spring.jwtaccess-token-expiration-minute=30",
-            "spring.jwt.refresh-token-expiration-minute=7200"
+                "spring.jwt.secret=sdjkjskjdkjskdjkswdnlkqwnlfkdnlkqwnfkqwnf",
+                "spring.jwt.issuer=compono",
+                "spring.jwt.access-token-expiration-minute=30",
+                "spring.jwt.refresh-token-expiration-minute=7200"
         })
 class JwtProviderTest {
 
-    @Autowired private JwtProvider jwtProvider;
+    @Autowired
+    private JwtProvider jwtProvider;
 
     @Test
     void createAccessToken() {

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -11,17 +11,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @DisplayName("JWT 발급, 파싱 테스트")
-@SpringBootTest(classes = {JwtProvider.class},
+@SpringBootTest(
+        classes = {JwtProvider.class},
         properties = {
-                "jwt.secret=sdjkjskjdkjskdjkswdnlkqwnlfkdnlkqwnfkqwnf",
-                "jwt.issuer=compono",
-                "jwt.access-token-expiration-minute=30",
-                "jwt.refresh-token-expiration-minute=7200"}
-)
+            "spring.jwt.secret=sdjkjskjdkjskdjkswdnlkqwnlfkdnlkqwnfkqwnf",
+            "spring.jwt.issuer=compono",
+            "spring.jwtaccess-token-expiration-minute=30",
+            "spring.jwt.refresh-token-expiration-minute=7200"
+        })
 class JwtProviderTest {
 
-    @Autowired
-    private JwtProvider jwtProvider;
+    @Autowired private JwtProvider jwtProvider;
 
     @Test
     void createAccessToken() {

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -3,13 +3,13 @@ package com.compono.ibackend.common.utils.jwt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
+@DisplayName("JWT 발급, 파싱 테스트")
 @SpringBootTest(classes = {JwtProvider.class})
-@ActiveProfiles("local")
 class JwtProviderTest {
 
     @Autowired

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -1,0 +1,46 @@
+package com.compono.ibackend.common.utils.jwt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.jsonwebtoken.Claims;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(classes = {JwtProvider.class})
+@ActiveProfiles("local")
+class JwtProviderTest {
+
+    @Autowired
+    private JwtProvider jwtProvider;
+
+    @Test
+    void createAccessToken() {
+        String email = "test@gmail.com";
+        String accessToken = jwtProvider.createAccessToken(email);
+
+        assertThat(accessToken).isNotNull();
+    }
+
+    @Test
+    void createRefreshToken() {
+        String email = "test@gmail.com";
+        String refreshToken = jwtProvider.createRefreshToken(email);
+
+        assertThat(refreshToken).isNotNull();
+    }
+
+    @Test
+    void getClaims() {
+        String email = "test@gmail.com";
+        String accessToken = jwtProvider.createAccessToken(email);
+
+        Claims claims = jwtProvider.getClaims(accessToken);
+        String subject = claims.getSubject();
+        String username = (String) claims.get("username");
+
+        assertThat(subject).isEqualTo(email);
+        assertThat(username).isEqualTo(email);
+    }
+}


### PR DESCRIPTION
- [x] ✅ PR 제목의 형식을 잘 작성했나요? e.g. `feat: PR을 등록한다.`
- [x] ✅ 테스트는 잘 통과했나요?
- [x] ✅ 빌드는 성공했나요?
- [x] ✅ 불필요한 코드는 제거했나요?
- [x] ✅ 이슈는 등록했나요?
- [x] ✅ 라벨은 등록했나요?
- [x] ✅ 코드 컨벤션은 지켰나요?
- [x] ✅ pr 워크플로우를 돌려주세요.

## 작업 내용
1. jjwt 0.12.3 디펜던시 추가
2. JwtProvider 컴포넌트 추가
- AccessToken, RefreshToken 생성
- JWT Claim 파싱
3. JwtProviderTest Code 작성
- Coverage 100%
## 스크린샷

## 주의사항
- yml에 jwt.issuer, secret, access-token-expiration-minute, refresh-token-expiration-minute 작성후 사용
- 로컬에서는 구글 스탠다드인 30분(Access), 200일(Refresh)로 설정해놓고 개인적으로 사용 및 테스트
Closes #39