### PR TITLE
feat: oauth login API & 회원 가입 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ sonar {
         property 'sonar.language', 'java'
         property 'sonar.sourceEncoding', 'UTF-8'
         property 'sonar.exclusions', '**/test/**, **/Q*.java, **/*Doc*.java, **/resources/**, **/domain/** ,**/*Application*.java , **/*Config*.java,' +
-                '**/*Dto*.java,**/*DTO*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java, **/escapes/**, **/converter/**, **/enumType/**, **/*GoogleCalendar*.java'
+                '**/*Dto*.java,**/*DTO*.java, **/*Request*.java, **/*Response*.java ,**/*Exception*.java ,**/*ErrorCode*.java, **/escapes/**, **/converter/**, **/enumType/**, **/*GoogleCalendar*.java, **/filter/**, **/security/**, **/*OauthService*'
         property 'sonar.test.inclusions', '**/*Test.java'
         property 'sonar.java.coveragePlugin', 'jacoco'
         property 'sonar.coverage.jacoco.xmlReportPaths', jacocoDir.get().file("jacoco/index.xml").asFile

--- a/build.gradle
+++ b/build.gradle
@@ -104,7 +104,10 @@ private excludedClassFilesForReport(classDirectories) {
                         "**/escapes/**",
                         "**/converter/**",
                         "**/enumType/**",
-                        "**/*GoogleCalendar*"
+                        "**/*GoogleCalendar*",
+                        "**/filter/**",
+                        "**/security/**",
+                        "**/*OauthService*"
                 ])
             })
     )

--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+    //oauth
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 }
 
 test {

--- a/src/main/java/com/compono/ibackend/auth/controller/AuthController.java
+++ b/src/main/java/com/compono/ibackend/auth/controller/AuthController.java
@@ -1,0 +1,27 @@
+package com.compono.ibackend.auth.controller;
+
+import com.compono.ibackend.auth.dto.response.AuthRefreshResponse;
+import com.compono.ibackend.auth.service.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<AuthRefreshResponse> refresh(HttpServletRequest httpServletRequest,
+                                                       HttpServletResponse httpServletResponse) {
+
+        AuthRefreshResponse res = authService.refresh(httpServletRequest, httpServletResponse);
+        return ResponseEntity.ok().body(res);
+    }
+}

--- a/src/main/java/com/compono/ibackend/auth/dto/response/AuthRefreshResponse.java
+++ b/src/main/java/com/compono/ibackend/auth/dto/response/AuthRefreshResponse.java
@@ -1,0 +1,7 @@
+package com.compono.ibackend.auth.dto.response;
+
+public record AuthRefreshResponse(
+        Long id,
+        String email
+) {
+}

--- a/src/main/java/com/compono/ibackend/auth/service/AuthService.java
+++ b/src/main/java/com/compono/ibackend/auth/service/AuthService.java
@@ -1,0 +1,68 @@
+package com.compono.ibackend.auth.service;
+
+import com.compono.ibackend.auth.dto.response.AuthRefreshResponse;
+import com.compono.ibackend.common.enumType.ErrorCode;
+import com.compono.ibackend.common.exception.CustomException;
+import com.compono.ibackend.common.utils.jwt.JwtProvider;
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Date;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private static final String REFRESH_TOKEN_NAME = "refresh_token";
+    private static final String JWT_PREFIX = "Bearer ";
+
+    public AuthRefreshResponse refresh(HttpServletRequest httpServletRequest,
+                                       HttpServletResponse httpServletResponse) {
+
+        if (httpServletRequest.getCookies() == null) {
+            throw new CustomException(HttpStatus.UNAUTHORIZED, ErrorCode.NOT_EXIST_COOKIE);
+        }
+
+        String refreshToken = getCookieFromHttpServletRequest(httpServletRequest);
+        Claims claims = jwtProvider.getClaims(refreshToken);
+        String email = claims.getSubject();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.NOT_FOUND_USER_ID));
+
+        Date now = Date.from(Instant.now());
+        if (claims.getExpiration().before(now)) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.COOKIE_EXPIRATION);
+        }
+
+        Long userId = user.getId();
+        String newAccessTokenValue = jwtProvider.createAccessToken(user.getEmail());
+        String newAccessToken = JWT_PREFIX + newAccessTokenValue;
+        httpServletResponse.setHeader(HttpHeaders.AUTHORIZATION, newAccessToken);
+
+        return new AuthRefreshResponse(userId, email);
+    }
+
+    public Claims getClaims(String accessToken) {
+        return jwtProvider.getClaims(accessToken);
+    }
+
+    private String getCookieFromHttpServletRequest(HttpServletRequest httpServletRequest) {
+        Cookie cookie = Arrays.stream(httpServletRequest.getCookies())
+                .filter(c -> c.getName().equals(REFRESH_TOKEN_NAME))
+                .findFirst()
+                .orElseThrow(() -> new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.NOT_EXIST_COOKIE));
+        return cookie.getValue();
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/enumType/ErrorCode.java
+++ b/src/main/java/com/compono/ibackend/common/enumType/ErrorCode.java
@@ -16,9 +16,14 @@ public enum ErrorCode {
     OPEN_API_REQUEST_FAIL(4006, "OPEN API 요청에 실패하였습니다"),
     INVALID_EVENTDATETIME(4007, "유효한지 않은 EventDateTime 값입니다."),
     DUPLICATED_FAILED(4008, "이미 데이터가 존재합니다."),
+    NOT_FOUND_USER_ID(4009, "유저 ID가 존재하지 않습니다."),
 
     // 401
-    EXPIRED_TOKEN(4010, "만료된 토큰입니다.");
+    EXPIRED_TOKEN(4010, "만료된 토큰입니다."),
+    NOT_EXIST_COOKIE(4011, "쿠키가 존재하지 않습니다."),
+    COOKIE_EXPIRATION(4012, "만료된 리프레시 토큰입니다."),
+    INVALID_OAUTH_PROVIDER(4013, "유효한 OAUTH 제공자가 아닙니다."),
+    INVALID_TOKEN(4014, "유효한 토큰이 아닙니다.");
 
     private final int code;
     private final String msg;

--- a/src/main/java/com/compono/ibackend/common/security/filter/JwtVerificationFilter.java
+++ b/src/main/java/com/compono/ibackend/common/security/filter/JwtVerificationFilter.java
@@ -1,0 +1,65 @@
+package com.compono.ibackend.common.security.filter;
+
+import com.compono.ibackend.auth.service.AuthService;
+import com.compono.ibackend.common.enumType.ErrorCode;
+import com.compono.ibackend.common.security.impl.UserDetailsImpl;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+public class JwtVerificationFilter extends OncePerRequestFilter {
+
+    private static final String JWT_PREFIX = "Bearer ";
+    private final AuthService authService;
+
+    @Override
+    protected boolean shouldNotFilter(@NonNull HttpServletRequest request) {
+        String bearerToken = getAuthenticationHeaderValue(request);
+        return bearerToken == null || !bearerToken.startsWith(JWT_PREFIX);
+    }
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain)
+            throws ServletException, IOException {
+        try {
+            setAuthenticationToContext(request);
+        } catch (JwtException e) {
+            request.setAttribute("exception", ErrorCode.INVALID_TOKEN);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private void setAuthenticationToContext(HttpServletRequest request) {
+        Authentication authentication = createAuthentication(request);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private Authentication createAuthentication(HttpServletRequest request) {
+        String accessToken = getAuthenticationHeaderValue(request);
+        accessToken = accessToken.substring(JWT_PREFIX.length());
+
+        Claims claims = authService.getClaims(accessToken);
+        UserDetailsImpl userDetails = new UserDetailsImpl(claims);
+
+        return new UsernamePasswordAuthenticationToken(userDetails, userDetails.getPassword(),
+                userDetails.getAuthorities());
+    }
+
+    private String getAuthenticationHeaderValue(HttpServletRequest request) {
+        return request.getHeader(HttpHeaders.AUTHORIZATION);
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/security/impl/JpaUserDetailServiceImpl.java
+++ b/src/main/java/com/compono/ibackend/common/security/impl/JpaUserDetailServiceImpl.java
@@ -1,0 +1,25 @@
+package com.compono.ibackend.common.security.impl;
+
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class JpaUserDetailServiceImpl implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository
+                .findByEmail(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found in db"));
+
+        return new UserDetailsImpl(user);
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/security/impl/UserDetailsImpl.java
+++ b/src/main/java/com/compono/ibackend/common/security/impl/UserDetailsImpl.java
@@ -1,0 +1,67 @@
+package com.compono.ibackend.common.security.impl;
+
+import com.compono.ibackend.user.domain.User;
+import io.jsonwebtoken.Claims;
+import java.util.Collection;
+import java.util.List;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+@Getter
+public class UserDetailsImpl implements UserDetails {
+
+    private final Long id;
+    private final String email;
+
+    public UserDetailsImpl(Long id, String email) {
+        this.id = id;
+        this.email = email;
+    }
+
+    public UserDetailsImpl(Claims claims) {
+        this.id = claims.get("id", Long.class);
+        this.email = claims.getSubject();
+    }
+
+    public UserDetailsImpl(User user) {
+        this.id = user.getId();
+        this.email = user.getEmail();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
+++ b/src/main/java/com/compono/ibackend/common/utils/jwt/JwtProvider.java
@@ -28,16 +28,17 @@ public class JwtProvider {
     private long refreshTokenExpirationMinute;
 
     // Claim : JWT 에 넣을 내용(eg body, 부가적으로 사용할 정보를 넣을 수 있음)
-    private Map<String, Object> createClaims(String username) {
-        return Map.of("username", username);
+    private Map<String, Object> createClaims(String email) {
+
+        return Map.of("email", email);
     }
 
-    public String createAccessToken(String username) {
+    public String createAccessToken(String email) {
         Instant now = Instant.now();
-        Map<String, Object> claims = createClaims(username);
+        Map<String, Object> claims = createClaims(email);
         return Jwts.builder()
                 .issuer(issuer)
-                .subject(username)
+                .subject(email)
                 .claims(claims)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(accessTokenExpirationMinute, ChronoUnit.MINUTES)))
@@ -45,11 +46,11 @@ public class JwtProvider {
                 .compact();
     }
 
-    public String createRefreshToken(String username) {
+    public String createRefreshToken(String email) {
         Instant now = Instant.now();
         return Jwts.builder()
                 .issuer(issuer)
-                .subject(username)
+                .subject(email)
                 .issuedAt(Date.from(now))
                 .expiration(Date.from(now.plus(refreshTokenExpirationMinute, ChronoUnit.MINUTES)))
                 .signWith(getSecretKey())

--- a/src/main/java/com/compono/ibackend/config/SecurityConfig.java
+++ b/src/main/java/com/compono/ibackend/config/SecurityConfig.java
@@ -14,7 +14,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @Configuration
 public class SecurityConfig {
 
-    private static final String[] DEFAULT_WHITELIST = {"/status", "/images/**", "/error/**"};
+    private static final String[] DEFAULT_WHITELIST = {"/status", "/images/**", "/error/**", "/api/v1/oauth/**"};
 
     private static final String[] DEVELOP_TEST_PATH = {"api/develop/**", "/api/develop/**"};
 

--- a/src/main/java/com/compono/ibackend/config/SecurityConfig.java
+++ b/src/main/java/com/compono/ibackend/config/SecurityConfig.java
@@ -1,30 +1,78 @@
 package com.compono.ibackend.config;
 
+import com.compono.ibackend.auth.service.AuthService;
+import com.compono.ibackend.common.security.filter.JwtVerificationFilter;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.CorsConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 
-    private static final String[] DEFAULT_WHITELIST = {"/status", "/images/**", "/error/**", "/api/v1/oauth/**"};
+    private final AuthService authService;
+
+    private static final String[] DEFAULT_WHITELIST = {"/status", "/images/**", "/error/**", "/api/v1/oauth/**",
+            "/api/v1/users/**"};
 
     private static final String[] DEVELOP_TEST_PATH = {"api/develop/**", "/api/develop/**"};
 
     @Bean
     protected SecurityFilterChain config(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable)
-                .cors(Customizer.withDefaults())
-                .authorizeHttpRequests(
-                        // todo : spring security 인가에 따른 접근권한 설정 필요
-                        request -> request.anyRequest().permitAll());
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(customCorsConfig())
+                .authorizeHttpRequests(request -> request
+                        .requestMatchers(DEFAULT_WHITELIST).permitAll()
+                        .anyRequest().authenticated()
+                )
+                .headers(header -> header
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(new JwtVerificationFilter(authService), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
+
+    @Bean
+    public Customizer<CorsConfigurer<HttpSecurity>> customCorsConfig() {
+        return httpSecurityCorsConfigurer -> {
+            httpSecurityCorsConfigurer.configurationSource(corsConfigurationSource());
+        };
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+        corsConfiguration.setAllowedOriginPatterns(List.of("*"));
+        corsConfiguration.setAllowedOrigins(List.of("http://localhost:3000", "https://www.axyz.today"));
+        corsConfiguration.setAllowedMethods(Arrays.asList("POST", "GET", "DELETE", "PATCH", "PUT", "OPTIONS"));
+        corsConfiguration.setAllowedHeaders(List.of("*"));
+        corsConfiguration.setAllowCredentials(true);
+        corsConfiguration.addExposedHeader("*");
+        corsConfiguration.addExposedHeader(HttpHeaders.AUTHORIZATION);
+        corsConfiguration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+        return source;
+    }
+
 }

--- a/src/main/java/com/compono/ibackend/oauth/controller/OauthController.java
+++ b/src/main/java/com/compono/ibackend/oauth/controller/OauthController.java
@@ -1,0 +1,50 @@
+package com.compono.ibackend.oauth.controller;
+
+import com.compono.ibackend.oauth.dto.request.OauthLoginRequest;
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.oauth.service.OauthService;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/api/v1/oauth")
+public class OauthController {
+
+    private final OauthService<OauthLoginRequest> kakaoOauthService;
+    private final OauthService<OauthLoginRequest> googleOauthService;
+
+
+    @GetMapping("/{provider}")
+    public ResponseEntity<OauthLoginResponse> oauthLoginCallback(@PathVariable String provider,
+                                                                 @RequestParam String code,
+                                                                 HttpServletResponse httpServletResponse) {
+        OauthLoginRequest oauthLoginRequestDTO = new OauthLoginRequest(provider, code);
+        if (isProviderKakao(provider)) {
+            OauthLoginResponse res = kakaoOauthService.login(oauthLoginRequestDTO, httpServletResponse);
+            return ResponseEntity.ok().body(res);
+        }
+
+        if (isProviderGoogle(provider)) {
+            OauthLoginResponse res = googleOauthService.login(oauthLoginRequestDTO, httpServletResponse);
+            return ResponseEntity.ok().body(res);
+        }
+
+        return null;
+    }
+
+    private boolean isProviderGoogle(String provider) {
+        return provider.equals(OauthProvider.GOOGLE.getValue());
+    }
+
+    private boolean isProviderKakao(String provider) {
+        return provider.equals(OauthProvider.KAKAO.getValue());
+    }
+}

--- a/src/main/java/com/compono/ibackend/oauth/domain/GoogleUserInfo.java
+++ b/src/main/java/com/compono/ibackend/oauth/domain/GoogleUserInfo.java
@@ -1,0 +1,41 @@
+package com.compono.ibackend.oauth.domain;
+
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class GoogleUserInfo implements OauthUserInfo {
+
+    private final Map<String, Object> attributes;
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return OauthProvider.GOOGLE.getValue();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickName() {
+        return (String) attributes.get("name");
+    }
+
+    public OauthLoginResponse from(boolean isRegistered) {
+        return new OauthLoginResponse(
+                getProviderId(),
+                getEmail(),
+                getNickName(),
+                isRegistered
+        );
+    }
+}

--- a/src/main/java/com/compono/ibackend/oauth/domain/KakaoUserInfo.java
+++ b/src/main/java/com/compono/ibackend/oauth/domain/KakaoUserInfo.java
@@ -1,0 +1,50 @@
+package com.compono.ibackend.oauth.domain;
+
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class KakaoUserInfo implements OauthUserInfo {
+
+    private final Map<String, Object> attributes;
+
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getProvider() {
+        return OauthProvider.KAKAO.getValue();
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) getKakaoAccount().get("email");
+    }
+
+    @Override
+    public String getNickName() {
+        return (String) getProfile().get("nickname");
+    }
+
+    public Map<String, Object> getKakaoAccount() {
+        return (Map<String, Object>) attributes.get("kakao_account");
+    }
+
+    public Map<String, Object> getProfile() {
+        return (Map<String, Object>) getKakaoAccount().get("profile");
+    }
+
+    public OauthLoginResponse from(boolean isRegistered) {
+        return new OauthLoginResponse(
+                getProviderId(),
+                getEmail(),
+                getNickName(),
+                isRegistered
+        );
+    }
+}

--- a/src/main/java/com/compono/ibackend/oauth/domain/OauthUserInfo.java
+++ b/src/main/java/com/compono/ibackend/oauth/domain/OauthUserInfo.java
@@ -1,0 +1,11 @@
+package com.compono.ibackend.oauth.domain;
+
+public interface OauthUserInfo {
+    String getProviderId();
+
+    String getProvider();
+
+    String getEmail();
+
+    String getNickName();
+}

--- a/src/main/java/com/compono/ibackend/oauth/dto/OauthTokenDTO.java
+++ b/src/main/java/com/compono/ibackend/oauth/dto/OauthTokenDTO.java
@@ -1,0 +1,21 @@
+package com.compono.ibackend.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OauthTokenDTO(
+        @JsonProperty(value = "token_type")
+        String tokenType,
+
+        @JsonProperty(value = "access_token")
+        String accessToken,
+
+        @JsonProperty(value = "expires_in")
+        Integer expiresIn,
+
+        @JsonProperty(value = "refresh_token")
+        String refreshToken,
+
+        @JsonProperty(value = "refresh_token_expires_in")
+        Integer refreshTokenExpiresIn
+) {
+}

--- a/src/main/java/com/compono/ibackend/oauth/dto/request/OauthLoginRequest.java
+++ b/src/main/java/com/compono/ibackend/oauth/dto/request/OauthLoginRequest.java
@@ -1,0 +1,7 @@
+package com.compono.ibackend.oauth.dto.request;
+
+public record OauthLoginRequest(
+        String provider,
+        String code
+) {
+}

--- a/src/main/java/com/compono/ibackend/oauth/dto/response/OauthLoginResponse.java
+++ b/src/main/java/com/compono/ibackend/oauth/dto/response/OauthLoginResponse.java
@@ -1,0 +1,9 @@
+package com.compono.ibackend.oauth.dto.response;
+
+public record OauthLoginResponse(
+        String oauthProviderUniqueKey,
+        String email,
+        String nickname,
+        boolean isRegistered
+) {
+}

--- a/src/main/java/com/compono/ibackend/oauth/service/GoogleOauthService.java
+++ b/src/main/java/com/compono/ibackend/oauth/service/GoogleOauthService.java
@@ -1,0 +1,130 @@
+package com.compono.ibackend.oauth.service;
+
+import com.compono.ibackend.common.enumType.ErrorCode;
+import com.compono.ibackend.common.exception.CustomException;
+import com.compono.ibackend.common.utils.jwt.JwtProvider;
+import com.compono.ibackend.oauth.domain.GoogleUserInfo;
+import com.compono.ibackend.oauth.dto.OauthTokenDTO;
+import com.compono.ibackend.oauth.dto.request.OauthLoginRequest;
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import com.compono.ibackend.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GoogleOauthService implements OauthService<OauthLoginRequest> {
+
+    private final InMemoryClientRegistrationRepository clientRegistrationRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    private static final String REFRESH_TOKEN_NAME = "refresh_token";
+    private static final int COOKIE_MAX_AGE = 60 * 60 * 24 * 200;
+
+    @Override
+    public OauthLoginResponse login(OauthLoginRequest param, HttpServletResponse httpServletResponse) {
+
+        ClientRegistration provider = clientRegistrationRepository.findByRegistrationId(
+                param.provider());
+        OauthTokenDTO oauthToken = getOauthToken(param.code(), provider);
+
+        GoogleUserInfo googleUser = getUserInfoFromGoogle(param.provider(), oauthToken, provider);
+        String oauthProviderUniqueKey = googleUser.getProviderId();
+
+        Optional<User> optionalUser =
+                userRepository.findByOauthProviderUniqueKey(oauthProviderUniqueKey);
+        boolean isRegistered;
+        if (optionalUser.isPresent()) {
+            User user = optionalUser.get();
+            String accessToken = jwtProvider.createAccessToken(user.getEmail());
+            httpServletResponse.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+
+            String refreshToken = jwtProvider.createRefreshToken(user.getEmail());
+            ResponseCookie cookie = createCookie(refreshToken);
+            httpServletResponse.setHeader("Set-Cookie", cookie.toString());
+
+            isRegistered = true;
+        } else {
+            // 등록된 유저가 아닌 경우: 프론트에서 Oauth 유저 정보를 기반으로 회원가입 페이지로 랜딩
+            isRegistered = false;
+        }
+
+        return googleUser.from(isRegistered);
+    }
+
+    private OauthTokenDTO getOauthToken(String code, ClientRegistration provider) {
+        return WebClient.create()
+                .post()
+                .uri(provider.getProviderDetails().getTokenUri())
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(createOauthRequestBody(code, provider))
+                .retrieve()
+                .bodyToMono(OauthTokenDTO.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> createOauthRequestBody(String code, ClientRegistration provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("client_id", provider.getClientId());
+        return formData;
+    }
+
+    private GoogleUserInfo getUserInfoFromGoogle(String providerName, OauthTokenDTO oauthToken,
+                                                 ClientRegistration provider) {
+        if (!providerName.equals(OauthProvider.GOOGLE.getValue())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_OAUTH_PROVIDER);
+        }
+        Map<String, Object> userAttributes = getUserAttribute(provider, oauthToken);
+        return new GoogleUserInfo(userAttributes);
+    }
+
+    private Map<String, Object> getUserAttribute(ClientRegistration provider, OauthTokenDTO oauthToken) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(String.valueOf(oauthToken.accessToken())))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+    }
+
+    private ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_NAME, refreshToken)
+                .maxAge(COOKIE_MAX_AGE)
+                .domain("compono")
+                .path("/")
+                .secure(true)
+                .sameSite(SameSite.NONE.name())
+                .httpOnly(true)
+                .build();
+    }
+}

--- a/src/main/java/com/compono/ibackend/oauth/service/KakaoOauthService.java
+++ b/src/main/java/com/compono/ibackend/oauth/service/KakaoOauthService.java
@@ -1,0 +1,129 @@
+package com.compono.ibackend.oauth.service;
+
+import com.compono.ibackend.common.enumType.ErrorCode;
+import com.compono.ibackend.common.exception.CustomException;
+import com.compono.ibackend.common.utils.jwt.JwtProvider;
+import com.compono.ibackend.oauth.domain.KakaoUserInfo;
+import com.compono.ibackend.oauth.dto.OauthTokenDTO;
+import com.compono.ibackend.oauth.dto.request.OauthLoginRequest;
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import com.compono.ibackend.user.repository.UserRepository;
+import jakarta.servlet.http.HttpServletResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.web.server.Cookie.SameSite;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.InMemoryClientRegistrationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoOauthService implements OauthService<OauthLoginRequest> {
+
+    private final InMemoryClientRegistrationRepository clientRegistrationRepository;
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    private static final String REFRESH_TOKEN_NAME = "refresh_token";
+    private static final int COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+    @Override
+    public OauthLoginResponse login(OauthLoginRequest param, HttpServletResponse httpServletResponse) {
+
+        ClientRegistration provider = clientRegistrationRepository.findByRegistrationId(
+                param.provider());
+        OauthTokenDTO oauthToken = getOauthToken(param.code(), provider);
+
+        KakaoUserInfo kakaoUser = getUserInfoFromKakao(param.provider(), oauthToken, provider);
+        String oauthProviderUniqueKey = kakaoUser.getProviderId();
+
+        Optional<User> optionalUser =
+                userRepository.findByOauthProviderUniqueKey(oauthProviderUniqueKey);
+        boolean isRegistered;
+        if (optionalUser.isPresent()) {
+            User user = optionalUser.get();
+            String accessToken = jwtProvider.createAccessToken(user.getEmail());
+            httpServletResponse.setHeader(HttpHeaders.AUTHORIZATION, accessToken);
+
+            String refreshToken = jwtProvider.createRefreshToken(user.getEmail());
+            ResponseCookie cookie = createCookie(refreshToken);
+            httpServletResponse.setHeader("Set-Cookie", cookie.toString());
+
+            isRegistered = true;
+        } else {
+            // 등록된 유저가 아닌 경우: 프론트에서 Oauth 유저 정보를 기반으로 회원가입 페이지로 랜딩
+            isRegistered = false;
+        }
+        return kakaoUser.from(isRegistered);
+    }
+
+    private OauthTokenDTO getOauthToken(String code, ClientRegistration provider) {
+        return WebClient.create()
+                .post()
+                .uri(provider.getProviderDetails().getTokenUri())
+                .headers(header -> {
+                    header.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+                    header.setAcceptCharset(Collections.singletonList(StandardCharsets.UTF_8));
+                })
+                .bodyValue(createOauthRequestBody(code, provider))
+                .retrieve()
+                .bodyToMono(OauthTokenDTO.class)
+                .block();
+    }
+
+    private MultiValueMap<String, String> createOauthRequestBody(String code, ClientRegistration provider) {
+        MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+        formData.add("code", code);
+        formData.add("grant_type", "authorization_code");
+        formData.add("redirect_uri", provider.getRedirectUri());
+        formData.add("client_secret", provider.getClientSecret());
+        formData.add("client_id", provider.getClientId());
+        return formData;
+    }
+
+    private KakaoUserInfo getUserInfoFromKakao(String providerName, OauthTokenDTO oauthToken,
+                                               ClientRegistration provider) {
+        if (!providerName.equals(OauthProvider.KAKAO.getValue())) {
+            throw new CustomException(HttpStatus.BAD_REQUEST, ErrorCode.INVALID_OAUTH_PROVIDER);
+        }
+        Map<String, Object> userAttributes = getUserAttribute(provider, oauthToken);
+        return new KakaoUserInfo(userAttributes);
+    }
+
+    private Map<String, Object> getUserAttribute(ClientRegistration provider, OauthTokenDTO oauthToken) {
+        return WebClient.create()
+                .get()
+                .uri(provider.getProviderDetails().getUserInfoEndpoint().getUri())
+                .headers(header -> header.setBearerAuth(String.valueOf(oauthToken.accessToken())))
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {
+                })
+                .block();
+    }
+
+    private ResponseCookie createCookie(String refreshToken) {
+        return ResponseCookie.from(REFRESH_TOKEN_NAME, refreshToken)
+                .maxAge(COOKIE_MAX_AGE)
+                .domain("axyz")
+                .path("/")
+                .secure(true)
+                .sameSite(SameSite.NONE.name())
+                .httpOnly(true)
+                .build();
+    }
+}

--- a/src/main/java/com/compono/ibackend/oauth/service/OauthService.java
+++ b/src/main/java/com/compono/ibackend/oauth/service/OauthService.java
@@ -1,0 +1,8 @@
+package com.compono.ibackend.oauth.service;
+
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import jakarta.servlet.http.HttpServletResponse;
+
+public interface OauthService<T> {
+    OauthLoginResponse login(T oauthLoginRequestDTO, HttpServletResponse httpServletResponse);
+}

--- a/src/main/java/com/compono/ibackend/user/controller/UserController.java
+++ b/src/main/java/com/compono/ibackend/user/controller/UserController.java
@@ -1,0 +1,26 @@
+package com.compono.ibackend.user.controller;
+
+import com.compono.ibackend.user.dto.request.UserAddRequest;
+import com.compono.ibackend.user.dto.response.UserAddResponse;
+import com.compono.ibackend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<UserAddResponse> addUser(@RequestBody UserAddRequest request) {
+        UserAddResponse response = userService.addUser(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/compono/ibackend/user/domain/User.java
+++ b/src/main/java/com/compono/ibackend/user/domain/User.java
@@ -3,6 +3,7 @@ package com.compono.ibackend.user.domain;
 import static lombok.AccessLevel.PROTECTED;
 
 import com.compono.ibackend.common.converter.AES256ToStringConverter;
+import com.compono.ibackend.user.dto.request.UserAddRequest;
 import com.compono.ibackend.user.enumType.OauthProvider;
 import com.compono.ibackend.user.enumType.UserStatus;
 import jakarta.persistence.Column;
@@ -14,8 +15,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "`user`")
@@ -47,4 +50,23 @@ public class User {
     @Enumerated(EnumType.STRING)
     @Column(name = "user_status", nullable = false)
     private UserStatus userStatus;
+
+    private User(String email, String nickname, OauthProvider oauthProvider, String oauthProviderUniqueKey,
+                 Boolean isAuthenticated) {
+        this.email = email;
+        this.nickname = nickname;
+        this.oauthProvider = oauthProvider;
+        this.oauthProviderUniqueKey = oauthProviderUniqueKey;
+        this.isAuthenticated = isAuthenticated;
+        this.userStatus = UserStatus.ACTIVE;
+    }
+
+    public static User from(UserAddRequest request) {
+        return new User(
+                request.email(),
+                request.nickname(),
+                request.oauthProvider(),
+                request.oauthProviderUniqueKey(),
+                request.isAuthenticated());
+    }
 }

--- a/src/main/java/com/compono/ibackend/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/compono/ibackend/user/domain/repository/UserRepository.java
@@ -1,8 +1,0 @@
-package com.compono.ibackend.user.domain.repository;
-
-import com.compono.ibackend.user.domain.User;
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
-
-@Repository
-public interface UserRepository extends JpaRepository<User, Long> {}

--- a/src/main/java/com/compono/ibackend/user/dto/request/UserAddRequest.java
+++ b/src/main/java/com/compono/ibackend/user/dto/request/UserAddRequest.java
@@ -1,0 +1,16 @@
+package com.compono.ibackend.user.dto.request;
+
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.enumType.OauthProvider;
+
+public record UserAddRequest(
+        String email,
+        String nickname,
+        OauthProvider oauthProvider,
+        String oauthProviderUniqueKey,
+        Boolean isAuthenticated
+) {
+    public User toEntity() {
+        return User.from(this);
+    }
+}

--- a/src/main/java/com/compono/ibackend/user/dto/response/UserAddResponse.java
+++ b/src/main/java/com/compono/ibackend/user/dto/response/UserAddResponse.java
@@ -1,0 +1,13 @@
+package com.compono.ibackend.user.dto.response;
+
+import com.compono.ibackend.user.domain.User;
+
+public record UserAddResponse(
+        Long id,
+        String email,
+        String nickname
+) {
+    public static UserAddResponse from(User user) {
+        return new UserAddResponse(user.getId(), user.getEmail(), user.getNickname());
+    }
+}

--- a/src/main/java/com/compono/ibackend/user/enumType/OauthProvider.java
+++ b/src/main/java/com/compono/ibackend/user/enumType/OauthProvider.java
@@ -1,7 +1,14 @@
 package com.compono.ibackend.user.enumType;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
 public enum OauthProvider {
-    GOOGLE,
-    KAKAO,
-    APPLE
+    GOOGLE("google"),
+    KAKAO("kakao"),
+    APPLE("apple");
+
+    private final String value;
 }

--- a/src/main/java/com/compono/ibackend/user/repository/UserRepository.java
+++ b/src/main/java/com/compono/ibackend/user/repository/UserRepository.java
@@ -1,0 +1,14 @@
+package com.compono.ibackend.user.repository;
+
+import com.compono.ibackend.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauthProviderUniqueKey(String oauthProviderUniqueKey);
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/compono/ibackend/user/service/UserService.java
+++ b/src/main/java/com/compono/ibackend/user/service/UserService.java
@@ -1,0 +1,24 @@
+package com.compono.ibackend.user.service;
+
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.dto.request.UserAddRequest;
+import com.compono.ibackend.user.dto.response.UserAddResponse;
+import com.compono.ibackend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserAddResponse addUser(UserAddRequest request) {
+        //TODO request validation
+        User user = request.toEntity();
+        userRepository.save(user);
+        return UserAddResponse.from(user);
+    }
+}

--- a/src/test/java/com/compono/ibackend/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/compono/ibackend/auth/controller/AuthControllerTest.java
@@ -1,0 +1,82 @@
+package com.compono.ibackend.auth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.compono.ibackend.auth.dto.response.AuthRefreshResponse;
+import com.compono.ibackend.auth.service.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] - 인증")
+@WebMvcTest(AuthController.class)
+@AutoConfigureRestDocs
+class AuthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private AuthService authService;
+
+
+    @DisplayName("{POST} Access Token 리프레시 - 정상호출")
+    @Test
+    @WithMockUser(
+            username = "ADMIN",
+            roles = {"SUPER"})
+    void refresh() throws Exception {
+        when(authService.refresh(any(HttpServletRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(createAuthRefreshResponse());
+
+        mvc.perform(
+                        RestDocumentationRequestBuilders.post("/api/v1/auth/refresh")
+                                .with(csrf().asHeader())
+                                .cookie(new Cookie("refresh-token", UUID.randomUUID().toString())))
+                .andDo(print())
+                .andDo(
+                        document(
+                                "auth-refresh",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("id")
+                                                .type(NUMBER)
+                                                .description("유저 id"),
+                                        fieldWithPath("email")
+                                                .type(STRING)
+                                                .description("유저 이메일")
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    private AuthRefreshResponse createAuthRefreshResponse() {
+        Long id = 1L;
+        String email = "test@gmail.com";
+        return new AuthRefreshResponse(id, email);
+    }
+}

--- a/src/test/java/com/compono/ibackend/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/compono/ibackend/auth/service/AuthServiceTest.java
@@ -1,0 +1,141 @@
+package com.compono.ibackend.auth.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.compono.ibackend.auth.dto.response.AuthRefreshResponse;
+import com.compono.ibackend.common.exception.CustomException;
+import com.compono.ibackend.common.utils.jwt.JwtProvider;
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.dto.request.UserAddRequest;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import com.compono.ibackend.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.time.Instant;
+import java.util.Date;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private JwtProvider jwtProvider;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    HttpServletRequest httpServletRequest;
+
+    @Mock
+    HttpServletResponse httpServletResponse;
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Test
+    void refresh() {
+        String refreshTokenValue = UUID.randomUUID().toString();
+        String email = "compono@test.com";
+        Cookie cookie = new Cookie("refresh_token", refreshTokenValue);
+
+        when(httpServletRequest.getCookies())
+                .thenReturn(new Cookie[]{cookie});
+
+        when(jwtProvider.getClaims(anyString()))
+                .thenReturn(createClaims(email, 60L));
+
+        when(userRepository.findByEmail(email))
+                .thenReturn(Optional.of(createUser(email)));
+
+        AuthRefreshResponse response = authService.refresh(httpServletRequest, httpServletResponse);
+
+        assertThat(response.email()).isEqualTo(email);
+    }
+
+    @Test
+    void refresh_exception_when_cookies_null() {
+        when(httpServletRequest.getCookies())
+                .thenReturn(null);
+
+        assertThatThrownBy(() -> authService.refresh(httpServletRequest, httpServletResponse))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void refresh_exception_when_refresh_token_expired() {
+        String refreshTokenValue = UUID.randomUUID().toString();
+        Cookie cookie = new Cookie("refresh_token", refreshTokenValue);
+        String email = "compono@test.com";
+
+        when(jwtProvider.getClaims(anyString()))
+                .thenReturn(createClaims(email, -10L));
+
+        when(userRepository.findByEmail(email))
+                .thenReturn(Optional.of(createUser(email)));
+
+        when(httpServletRequest.getCookies())
+                .thenReturn(new Cookie[]{cookie});
+
+        assertThatThrownBy(() -> authService.refresh(httpServletRequest, httpServletResponse))
+                .isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void refresh_exception_when_email_not_exist() {
+        String refreshTokenValue = UUID.randomUUID().toString();
+        String email = "compono@test.com";
+        Cookie cookie = new Cookie("refresh_token", refreshTokenValue);
+
+        when(httpServletRequest.getCookies())
+                .thenReturn(new Cookie[]{cookie});
+
+        when(jwtProvider.getClaims(anyString()))
+                .thenReturn(createClaims(email, 60L));
+
+        when(userRepository.findByEmail(email))
+                .thenThrow(CustomException.class);
+
+        assertThatThrownBy(() -> authService.refresh(httpServletRequest, httpServletResponse))
+                .isInstanceOf(CustomException.class);
+
+    }
+
+    @Test
+    void getClaims() {
+        String accessToken = UUID.randomUUID().toString();
+        String email = "compono@test.com";
+        when(jwtProvider.getClaims(anyString()))
+                .thenReturn(createClaims(email, 60L));
+
+        Claims claims = authService.getClaims(accessToken);
+
+        assertThat(claims.getSubject()).isEqualTo(email);
+    }
+
+    private Claims createClaims(String email, Long expiredTime) {
+        return Jwts.claims()
+                .id("jti")
+                .subject(email)
+                .expiration(Date.from(Instant.now().plusSeconds(expiredTime)))
+                .build();
+    }
+
+    private User createUser(String email) {
+        UserAddRequest request = new UserAddRequest(email, "compono", OauthProvider.KAKAO, UUID.randomUUID().toString(),
+                true);
+        return User.from(request);
+    }
+}

--- a/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
+++ b/src/test/java/com/compono/ibackend/common/utils/jwt/JwtProviderTest.java
@@ -43,15 +43,16 @@ class JwtProviderTest {
     @Test
     void getClaims() {
         Instant now = Instant.now();
-        String email = "test@gmail.com";
-        String accessToken = jwtProvider.createAccessToken(email);
+        String email1 = "test@gmail.com";
+        String accessToken = jwtProvider.createAccessToken(email1);
 
         Claims claims = jwtProvider.getClaims(accessToken);
         String subject = claims.getSubject();
-        String username = (String) claims.get("username");
 
-        assertThat(subject).isEqualTo(email);
-        assertThat(username).isEqualTo(email);
+        String email2 = (String) claims.get("email");
+
+        assertThat(subject).isEqualTo(email1);
+        assertThat(email1).isEqualTo(email2);
         assertThat(claims.getExpiration()).isBefore(now.plus(7199, ChronoUnit.MINUTES));
     }
 }

--- a/src/test/java/com/compono/ibackend/oauth/controller/GoogleOauthControllerTest.java
+++ b/src/test/java/com/compono/ibackend/oauth/controller/GoogleOauthControllerTest.java
@@ -1,0 +1,88 @@
+package com.compono.ibackend.oauth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.compono.ibackend.oauth.dto.request.OauthLoginRequest;
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.oauth.service.OauthService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] - Oauth")
+@WebMvcTest(OauthController.class)
+@AutoConfigureRestDocs
+class GoogleOauthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private OauthService<OauthLoginRequest> googleOauthService;
+
+    @DisplayName("{GET} Oauth 로그인 google - 정상호출")
+    @Test
+    @WithMockUser(
+            username = "ADMIN",
+            roles = {"SUPER"})
+    void oauthLoginCallback() throws Exception {
+        when(googleOauthService.login(any(OauthLoginRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(createOauthLoginResponse());
+
+        mvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v1/oauth/{provider}", "google")
+                                .with(csrf().asHeader())
+                                .param("code", UUID.randomUUID().toString()))
+                .andDo(print())
+                .andDo(
+                        document(
+                                "oauth-login-google",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("oauthProviderUniqueKey")
+                                                .type(STRING)
+                                                .description("유저 Oauth 유니크 키"),
+                                        fieldWithPath("email")
+                                                .type(STRING)
+                                                .description("Oauth 등록 이메일"),
+                                        fieldWithPath("nickname")
+                                                .type(STRING)
+                                                .description("Oauth 등록 닉네임"),
+                                        fieldWithPath("isRegistered")
+                                                .type(BOOLEAN)
+                                                .description("회원가입 여부")
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    private OauthLoginResponse createOauthLoginResponse() {
+        String oauthProviderUniqueKey = UUID.randomUUID().toString();
+        String email = "compono@test.com";
+        String nickname = "compono";
+
+        return new OauthLoginResponse(oauthProviderUniqueKey, email, nickname, true);
+    }
+}

--- a/src/test/java/com/compono/ibackend/oauth/controller/KakaoOauthControllerTest.java
+++ b/src/test/java/com/compono/ibackend/oauth/controller/KakaoOauthControllerTest.java
@@ -1,0 +1,88 @@
+package com.compono.ibackend.oauth.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.compono.ibackend.oauth.dto.request.OauthLoginRequest;
+import com.compono.ibackend.oauth.dto.response.OauthLoginResponse;
+import com.compono.ibackend.oauth.service.OauthService;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] - Oauth")
+@WebMvcTest(OauthController.class)
+@AutoConfigureRestDocs
+class KakaoOauthControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private OauthService<OauthLoginRequest> kakaoOauthService;
+
+    @DisplayName("{GET} Oauth 로그인 kakao - 정상호출")
+    @Test
+    @WithMockUser(
+            username = "ADMIN",
+            roles = {"SUPER"})
+    void oauthLoginCallback() throws Exception {
+        when(kakaoOauthService.login(any(OauthLoginRequest.class), any(HttpServletResponse.class)))
+                .thenReturn(createOauthLoginResponse());
+
+        mvc.perform(
+                        RestDocumentationRequestBuilders.get("/api/v1/oauth/{provider}", "kakao")
+                                .with(csrf().asHeader())
+                                .param("code", UUID.randomUUID().toString()))
+                .andDo(print())
+                .andDo(
+                        document(
+                                "oauth-login-kakao",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                responseFields(
+                                        fieldWithPath("oauthProviderUniqueKey")
+                                                .type(STRING)
+                                                .description("유저 Oauth 유니크 키"),
+                                        fieldWithPath("email")
+                                                .type(STRING)
+                                                .description("Oauth 등록 이메일"),
+                                        fieldWithPath("nickname")
+                                                .type(STRING)
+                                                .description("Oauth 등록 닉네임"),
+                                        fieldWithPath("isRegistered")
+                                                .type(BOOLEAN)
+                                                .description("회원가입 여부")
+                                )
+                        )
+                )
+                .andExpect(status().isOk());
+    }
+
+    private OauthLoginResponse createOauthLoginResponse() {
+        String oauthProviderUniqueKey = UUID.randomUUID().toString();
+        String email = "compono@test.com";
+        String nickname = "compono";
+
+        return new OauthLoginResponse(oauthProviderUniqueKey, email, nickname, true);
+    }
+}

--- a/src/test/java/com/compono/ibackend/user/controller/UserControllerTest.java
+++ b/src/test/java/com/compono/ibackend/user/controller/UserControllerTest.java
@@ -1,0 +1,105 @@
+package com.compono.ibackend.user.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.JsonFieldType.BOOLEAN;
+import static org.springframework.restdocs.payload.JsonFieldType.NUMBER;
+import static org.springframework.restdocs.payload.JsonFieldType.STRING;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.compono.ibackend.user.dto.request.UserAddRequest;
+import com.compono.ibackend.user.dto.response.UserAddResponse;
+import com.compono.ibackend.user.service.UserService;
+import org.json.JSONObject;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+@DisplayName("[컨트롤러] - 유저")
+@WebMvcTest(UserController.class)
+@AutoConfigureRestDocs
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private UserService UserService;
+
+    @DisplayName("{POST} 회원등록 - 정상호출")
+    @WithMockUser(
+            username = "ADMIN",
+            roles = {"SUPER"})
+    @Test
+    void addUser() throws Exception {
+        JSONObject request = new JSONObject();
+        request.put("email", "compono@test.com");
+        request.put("nickname", "compono");
+        request.put("oauthProvider", "KAKAO");
+        request.put("oauthProviderUniqueKey", "1233543412");
+        request.put("isAuthenticated", true);
+
+        when(UserService.addUser(any(UserAddRequest.class)))
+                .thenReturn(createUserAddResponse());
+
+        mvc.perform(
+                        RestDocumentationRequestBuilders.post("/api/v1/users")
+                                .with(csrf().asHeader())
+                                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                                .content(request.toString()))
+                .andDo(print())
+                .andDo(
+                        document(
+                                "create-user",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestFields(
+                                        fieldWithPath("email")
+                                                .type(STRING)
+                                                .description("이메일"),
+                                        fieldWithPath("nickname")
+                                                .type(STRING)
+                                                .description("닉네임"),
+                                        fieldWithPath("oauthProvider")
+                                                .type(STRING)
+                                                .description("Oauth 제공자"),
+                                        fieldWithPath("oauthProviderUniqueKey")
+                                                .type(STRING)
+                                                .description("Oauth 유니크 키"),
+                                        fieldWithPath("isAuthenticated")
+                                                .type(BOOLEAN)
+                                                .description("인증 여부")),
+
+                                responseFields(
+                                        fieldWithPath("id")
+                                                .type(NUMBER)
+                                                .description("유저 id"),
+                                        fieldWithPath("email")
+                                                .type(STRING)
+                                                .description("이메일"),
+                                        fieldWithPath("nickname")
+                                                .type(STRING)
+                                                .description("닉네임"))))
+                .andExpect(status().isCreated());
+    }
+
+    public UserAddResponse createUserAddResponse() {
+        return new UserAddResponse(1L, "compono@test.com", "compono");
+    }
+}

--- a/src/test/java/com/compono/ibackend/user/service/UserServiceTest.java
+++ b/src/test/java/com/compono/ibackend/user/service/UserServiceTest.java
@@ -1,0 +1,45 @@
+package com.compono.ibackend.user.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.compono.ibackend.user.domain.User;
+import com.compono.ibackend.user.dto.request.UserAddRequest;
+import com.compono.ibackend.user.dto.response.UserAddResponse;
+import com.compono.ibackend.user.enumType.OauthProvider;
+import com.compono.ibackend.user.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+
+    @Test
+    void addUser() {
+        String email = "test@gmail.com";
+        String nickname = "tester";
+        OauthProvider oauthProvider = OauthProvider.KAKAO;
+        UserAddRequest request = new UserAddRequest(email, nickname, oauthProvider, null, true);
+
+        when(userRepository.save(any(User.class))).thenReturn(createUser(request));
+
+        UserAddResponse response = userService.addUser(request);
+
+        assertThat(response.email()).isEqualTo(email);
+    }
+
+    private User createUser(UserAddRequest request) {
+        return User.from(request);
+    }
+}


### PR DESCRIPTION
- [x] ✅ PR 제목의 형식을 잘 작성했나요? e.g. `feat: PR을 등록한다.`
- [ ] ✅ 테스트는 잘 통과했나요?
- [x] ✅ 빌드는 성공했나요?
- [ ] ✅ 불필요한 코드는 제거했나요?
- [x] ✅ 이슈는 등록했나요?
- [x] ✅ 라벨은 등록했나요?
- [x] ✅ 코드 컨벤션은 지켰나요?
- [x] ✅ pr 워크플로우를 돌려주세요.

## 작업 내용
PR 하나에 내용이 너무 많이 들어갔네요. 다음에는 좀 짧게 끊어서 올리도록 하겠습니다. ㅠ
1. oauth login api
- kakao, google oauth login api
  - 카카오, 구글 oauth 사용자 정보 조회
  - 정보 조회후 compono 서버에 등록되어 있다면 등록 여부 리턴
  - true 라면 토큰 발급
  - false 라면 회원 가입 페이지로 랜딩 필요
 - oauth 서비스 테스트 시 외부 oauth 서버와 통신에서 의존성 문제 때문에 일단 테스트에서 제외시켜 놈
   - 해당 부분 의존성 mocking 방법 찾는중 : 괜찮은 방법 아시는 분 추천 부탁드려요 :)
2. 시큐리티 설정
- 시큐리티 cors 및 jwtfilter 설정
- userdetails 클래스 및 관련 메서드 구현
3. auth API
- refresh token 으로 새로운 accessToken 발급 로직 구현
4. 회원가입 API
- 스켈렉톤 API : 고도화 필요 
## 스크린샷

## 주의사항
- oauth 로그인 관련 프로퍼티를 일단 localhost와 제 개인 키로 해놓았습니다.
- 해당 부분 공식 키가 추후 필요합니다.

Closes #44 